### PR TITLE
Update Bluez5 Uuid.vala

### DIFF
--- a/lib/bluez5/Uuid.vala
+++ b/lib/bluez5/Uuid.vala
@@ -24,8 +24,8 @@
 using GLib.Bus;
 
 namespace Bluez5.Uuid {
-    const string 16BIT_PREFIX = "0000";
-    const string BASE = "-0000-1000-8000-00805f9b34fb";
+    public const string 16BIT_PREFIX = "0000";
+    public const string BASE = "-0000-1000-8000-00805f9b34fb";
 
     /**
      * Bluetooth Core Specification


### PR DESCRIPTION
Suggestion to consider: when I built v3 (Thank you!) this weekend in the 'tinker Bookworm on 4.19' image, the updated valac included with Bookworm complained about these two strings not also being 'public' & only built once this change was made:

reference: https://github.com/donadigo/appeditor/issues/121